### PR TITLE
Add transient component support (Issue #7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -7,6 +7,8 @@ const std = @import("std");
 const ecs = @import("ecs");
 
 pub const Serializer = @import("serializer.zig").Serializer;
+pub const SerializerWithTransient = @import("serializer.zig").SerializerWithTransient;
+pub const isTransient = @import("serializer.zig").isTransient;
 pub const Config = @import("config.zig").Config;
 pub const Format = @import("config.zig").Format;
 pub const SaveMetadata = @import("metadata.zig").SaveMetadata;


### PR DESCRIPTION
## Summary
- Add `SerializerWithTransient` that filters out transient components from serialization
- Add `isTransient()` helper to check component markers
- Add `.gitignore` for build artifacts

## Use Cases
- Velocity/acceleration (recalculated each frame)
- Debug visualization components  
- Cached path-finding results
- Temporary UI state

## Usage
```zig
const GameSerializer = SerializerWithTransient(
    &[_]type{ Position, Velocity, Health },
    &[_]type{ Velocity },  // Transient - won't be saved
);
```

## Test plan
- [x] New test verifies transient components are excluded from JSON output
- [x] Existing tests still pass

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)